### PR TITLE
Pages about keys & crypto + bug fix

### DIFF
--- a/docs/.vuepress/components/Platform.vue
+++ b/docs/.vuepress/components/Platform.vue
@@ -1,16 +1,33 @@
 <template>
-  <section>
-    <article v-for="section in sections">
-      <h2>{{ section.dir }}</h2>
-      <ul>
+  <div>
+
+    <section v-for="section in sections">
+      <h2>{{ section.name }}</h2>
+
+      <ul v-if="!section.subsections">
         <li v-for="page in section.pages">
           <router-link :to="page.path">
             {{ page.title }}
           </router-link>
         </li>
       </ul>
-    </article>
-  </section>
+
+      <div v-if="section.subsections">
+        <article v-for="subsection in section.subsections">
+          <h4>{{ section.name }}</h4>
+
+          <ul>
+            <li v-for="page in subsection.pages">
+              <router-link :to="page.path">
+                {{ page.title }}
+              </router-link>
+            </li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+  </div>
 </template>
 
 <style scoped>
@@ -20,12 +37,18 @@ ul {
 </style>
 
 <script>
-const subdirectories = [
-  'Properties',
-  'Primitives',
-  'Methods',
-  'Operations',
-  'Plugins'
+const tree = [
+  { name: 'Properties' },
+  { name: 'Primitives', subsections: [
+    { name: 'Types' },
+    { name: 'Structs' }
+  ] },
+  { name: 'Methods' },
+  { name: 'Operations' },
+  { name: 'Plugins' },
+  { name: 'Protocol', subsections: [
+    { name: 'Crypto' }
+  ]}
 ]
 
 export default {
@@ -34,9 +57,15 @@ export default {
   },
   computed: {
     sections () {
-      return subdirectories.map(dir => ({
-        dir: dir,
-        pages: this.pages.filter(this.inDirectory(dir.toLowerCase()))
+      return tree.map(section => ({
+        name: section.name,
+        subsections: section.subsections ? section.subsections.map(subsection => ({
+          name: subsection.name,
+          pages: this.pages.filter(this.inDirectory(subsection.name.toLowerCase()))
+        })) : null,
+        pages: section.subsections 
+          ? null 
+          : this.pages.filter(this.inDirectory(section.name.toLowerCase()))
       }))
     }
   },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,6 @@
 var path = require('path')
 
 module.exports = {
-  palette: path.resolve(__dirname, 'palette.styl'),
   locales: {
     '/': {
       lang: 'en-CA',
@@ -45,12 +44,12 @@ module.exports = {
     }
   },
   plugins: {
-    '@vuepress/i18n-ui': true,
-    '@vuepress/back-to-top': true,
-    '@vuepress/pwa': {
-      serviceWorker: true,
-      updatePopup: true
-    },
-    '@vuepress/plugin-medium-zoom': true
+    // '@vuepress/i18n-ui': true,
+    // '@vuepress/back-to-top': true,
+    // '@vuepress/pwa': {
+    //   serviceWorker: true,
+    //   updatePopup: true
+    // },
+    // '@vuepress/plugin-medium-zoom': true
   }
 }

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -1,3 +1,1 @@
 $accentColor = #3D84FE
-
-@import './style.styl'

--- a/docs/platform/primitives/structs/authority.md
+++ b/docs/platform/primitives/structs/authority.md
@@ -1,5 +1,4 @@
-
-# `authority`
+# Authority (`authority`)
 
 An `authority` is a struct containing the following three fields:
 

--- a/docs/platform/primitives/structs/operation.md
+++ b/docs/platform/primitives/structs/operation.md
@@ -1,4 +1,4 @@
-# `operation`
+# Operation (`operation`)
 
 Operation refers both to the [actions that users may perform on the blockchain](/platform/operations/) and to the underlying struct that represent those actions.
 

--- a/docs/platform/primitives/structs/transaction.md
+++ b/docs/platform/primitives/structs/transaction.md
@@ -1,4 +1,4 @@
-# `transaction`
+# Transaction (`transaction`)
 
 Struct containing the following fields:
 

--- a/docs/platform/primitives/types/account_name.md
+++ b/docs/platform/primitives/types/account_name.md
@@ -1,4 +1,4 @@
-# `account_name_type`
+# Account Name (`account_name_type`)
 
 A valid account name consists of a dot-separated sequence of one or more labels consisting of the following rules:
  

--- a/docs/platform/primitives/types/asset.md
+++ b/docs/platform/primitives/types/asset.md
@@ -1,5 +1,4 @@
-
-# `asset_type`
+# Asset (`asset_type`)
 
 A string combining a (3 decimal places) floating-point number and an asset symbol. The asset symbol can be one of:
 

--- a/docs/platform/primitives/types/extension.md
+++ b/docs/platform/primitives/types/extension.md
@@ -1,2 +1,2 @@
-# `extension_type`
+# Extension (`extension_type`)
 

--- a/docs/platform/primitives/types/private_key.md
+++ b/docs/platform/primitives/types/private_key.md
@@ -1,4 +1,4 @@
-# Public Key (`public_key_type`)
+# Private Key (`private_key_type`)
 
 ## Related
 

--- a/docs/platform/primitives/types/signature.md
+++ b/docs/platform/primitives/types/signature.md
@@ -1,10 +1,14 @@
-# `signature_type`
+# Signature (`signature_type`)
 
 Alias for `compact_signature`.
 
 An elliptic curve signature represented as an array of 65 unsigned bytes.
 
 Given a public key, an algorithm can be used on the signature to determine that it was originally produced from a hash and a private key, without needing to know the private key.
+
+## Related
+
+- [Elliptic Curve Digital Signature Algorithm (ECDSA)](/platform/protocol/crypto/ecdsa.md)
 
 ## References
 

--- a/docs/platform/primitives/types/weight.md
+++ b/docs/platform/primitives/types/weight.md
@@ -1,0 +1,2 @@
+# Weight (`weight_type`)
+

--- a/docs/platform/protocol/crypto/ecdsa.md
+++ b/docs/platform/protocol/crypto/ecdsa.md
@@ -1,0 +1,19 @@
+# Elliptic Curve Digital Signature Algorithm (ECDSA)
+
+Elliptic Curve Digital Signature Algorithm or ECDSA is a cryptographic algorithm to ensure that funds can only be spent by their rightful owners.
+
+## Related
+
+- [Public Key (`public_key_type`)](/platform/primitives/types/public_key.md)
+- [Private Key (`private_key_type`)](/platform/primitives/types/private_key.md)
+- [Signature (`signature_type`)](/platform/primitives/types/signature.md)
+
+## See Also
+
+- [Secp256k1](/platform/protocol/crypto/secp256k1.md)
+
+## References
+
+- https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+- [SEC 2: Recommended Elliptic Curve Domain Parameters](http://www.secg.org/sec2-v2.pdf)
+- https://en.bitcoin.it/wiki/Secp256k1

--- a/docs/platform/protocol/crypto/secp256k1.md
+++ b/docs/platform/protocol/crypto/secp256k1.md
@@ -1,0 +1,8 @@
+# Secp256k1
+
+`secp256k1 refers to the parameters of the elliptic curve used in Steem's 
+public-key cryptography, and is defined in [Standards for Efficient Cryptography (SEC) (Certicom Research)](http://www.secg.org/sec2-v2.pdf).
+
+## See also
+
+- [Elliptic Curve Digital Signature Algorithm (ECDSA)](/platform/protocol/crypto/ecdsa.md)


### PR DESCRIPTION
- Modify platform page to add support for subsections
- Add /protocol to platform index
- Add two /protocol/crypto pages (ecdsa & secp256k1)
- Add private_key_type and link with new crypto pages
- Fix color palette bug (palette config file has moved in latest Vuepress version)
- Give formatted titles to pages that had only \`\` in their name
